### PR TITLE
Add empty imput field to protect against bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# savvy_mailer
+
+## To run the app
+- create and `account.yaml` file from the example
+- `ruby mailer.rb` to launch the Sinatra app
+- change the `action` on the index.html form to `http://localhost:9494/`
+- run the index in a browser or with a simple server
+- fill out the form and submit
+

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
     <p>Email:<input id="email" name="email" type="text" class="validate"/></p>
     <button id="submit" type="submit">Submit
     </button>
+    <input id="verify" name="verify" type="text" style="visibility: hidden">
   </form>
 </body>
 </html>

--- a/mailer.rb
+++ b/mailer.rb
@@ -54,10 +54,12 @@ post '/' do
 
   ActionMailer::Base.smtp_settings = account_configuration[:smtp]
 
-  Mailer.notification(params, account_configuration[:account]).deliver_now
+  if params['verify'].nil? || params['verify'].empty?
+    Mailer.notification(params, account_configuration[:account]).deliver_now
+  end
+
   after_success = params.fetch("after_success", account_configuration[:account][:after_success])
   redirect after_success
-
 end
 
 get '/' do

--- a/mailer.rb
+++ b/mailer.rb
@@ -42,15 +42,19 @@ class Mailer < ActionMailer::Base
   end
 end
 
-accounts = YAML.load_file('accounts.yaml').deep_symbolize_keys!
+if File.exists? 'accounts.yaml'
+  set :accounts, YAML.load_file('accounts.yaml').deep_symbolize_keys!
+else
+  set :accounts, {}
+end
 
 post '/' do
-  public_token = params['public_token'].to_sym
-  account_configuration = accounts[public_token]
 
-  redirect '/error' unless account_configuration
 
   # redirect account_configuration[:account][:after_failure]
+    public_token = params['public_token'].to_sym
+    account_configuration = settings.accounts[public_token]
+    redirect '/error' unless account_configuration
 
   ActionMailer::Base.smtp_settings = account_configuration[:smtp]
 
@@ -66,7 +70,7 @@ get '/' do
   payloadStr = Base64.decode64(params['payload'])
   payload = CGI::parse payloadStr
   public_token = payload['public_token'].first.to_sym
-  account_configuration = accounts[public_token]
+  account_configuration = settings.accounts[public_token]
 
   ActionMailer::Base.smtp_settings = account_configuration[:smtp]
 

--- a/mailer.rb
+++ b/mailer.rb
@@ -49,12 +49,13 @@ else
 end
 
 post '/' do
-
-
-  # redirect account_configuration[:account][:after_failure]
+  if params['public_token']
     public_token = params['public_token'].to_sym
     account_configuration = settings.accounts[public_token]
     redirect '/error' unless account_configuration
+  else
+    redirect '/error'
+  end
 
   ActionMailer::Base.smtp_settings = account_configuration[:smtp]
 

--- a/tests/test.rb
+++ b/tests/test.rb
@@ -21,14 +21,46 @@ class MyTest < MiniTest::Test
     post '/', { public_token: 'default',
                 name: 'butt',
                 email: 'butt@tp.com',
+                text_area: 'hi smelly',
                 verify: '',
                 action: 'value' }
 
-    assert last_response.ok?
+    assert last_response.redirect?
+    assert_includes last_response.location, 'success.html'
+
     delivered_email = ActionMailer::Base.deliveries.last
-    assert_includes delivered_email.to, 'paul@savvysoftworks.com'
+    assert_includes delivered_email.to, 'noreply@savvysoftworks.com'
     assert_includes delivered_email.body, 'hi smelly'
-    assert_includes delivered_email.subject, 'butt@tp.com'
+    assert_includes delivered_email.subject, 'http://savvysoftworks.com'
+  end
+
+  def test_mailer_nill_verify
+    post '/', { public_token: 'default',
+                name: 'butt',
+                email: 'butt@tp.com',
+                text_area: 'hi smelly',
+                action: 'value' }
+
+    assert last_response.redirect?
+    assert_includes last_response.location, 'success.html'
+
+    delivered_email = ActionMailer::Base.deliveries.last
+    assert_includes delivered_email.to, 'noreply@savvysoftworks.com'
+    assert_includes delivered_email.body, 'hi smelly'
+    assert_includes delivered_email.subject, 'http://savvysoftworks.com'
+  end
+
+  def test_mailer_with_verification_filled_in
+    post '/', { public_token: 'default',
+                name: 'butt',
+                email: 'butt@tp.com',
+                text_area: 'hi smelly',
+                verify: 'I am a robot',
+                action: 'value' }
+
+    assert last_response.redirect?
+    delivered_email = ActionMailer::Base.deliveries.last
+    assert_nil delivered_email
   end
 
   def test_mailer_redirects_to_error_without_configured_account

--- a/tests/test.rb
+++ b/tests/test.rb
@@ -19,7 +19,7 @@ class MyTest < MiniTest::Test
     post '/', { public_token: 'default',
                 name: 'butt',
                 email: 'butt@tp.com',
-                textarea: 'hi smelly',
+                verify: '',
                 action: 'value' }
 
     assert last_response.ok?
@@ -30,10 +30,10 @@ class MyTest < MiniTest::Test
   end
 
   def test_mailer_redirects_to_error_without_configured_account
-    post '/', {name: 'butt',
-               email: 'butt@tp.com',
-               textarea: 'hi smelly',
-               action: 'value'}
+    post '/', { name: 'butt',
+                email: 'butt@tp.com',
+                verify: '',
+                action: 'value' }
 
     assert last_response.redirect?
     follow_redirect!
@@ -44,7 +44,7 @@ class MyTest < MiniTest::Test
     post '/', { public_token: 'no-account',
                 name: 'butt',
                 email: 'butt@tp.com',
-                textarea: 'hi smelly',
+                verify: '',
                 action: 'value' }
 
     assert last_response.redirect?

--- a/tests/test.rb
+++ b/tests/test.rb
@@ -6,7 +6,9 @@ class MyTest < MiniTest::Test
   include Rack::Test::Methods
 
   def app
-    Sinatra::Application
+    app = Sinatra::Application
+    app.set :accounts, YAML.load_file('example.accounts.yaml').deep_symbolize_keys!
+    app
   end
 
   def setup

--- a/views/error.haml
+++ b/views/error.haml
@@ -1,1 +1,1 @@
-<h1>Account Not Configured</h1>
+%h1 Account Not Configured


### PR DESCRIPTION
###### Add empty input field to protect against bots

- Added empty field to index.html
- add check/guard in `mailer.rb` to verify the field is `empty?`, if it is not, redirect to `err_bot.haml`
- added test